### PR TITLE
Fix malformed description header

### DIFF
--- a/magit-filenotify.el
+++ b/magit-filenotify.el
@@ -1,4 +1,4 @@
-;;; magit-filenotify --- Refresh status buffer when git tree changes -*- lexical-binding: t -*-
+;;; magit-filenotify.el --- Refresh status buffer when git tree changes -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013 Rüdiger Sonderfeld
 


### PR DESCRIPTION
This slight mistake has been preventing MELPA from displaying a package description for magit-filenotify.
