### PR TITLE
Remedy for delay caused by temp files triggering magit-refresh

### DIFF
--- a/magit-filenotify.el
+++ b/magit-filenotify.el
@@ -40,6 +40,12 @@
   :prefix "magit-filenotify"
   :group 'magit)
 
+(defcustom magit-filenotify-ignored '("\\`\\.#"
+                                   "\\`flycheck_")
+  "A list of regexp for filenames that will be ignored by the callback."
+  :group 'magit-filenotify
+  :type '(repeat regexp))
+
 (defun magit-filenotify--directories ()
   "List all directories containing files watched by git."
   ;; TODO: add .git directory?
@@ -54,10 +60,6 @@
 
 (defvar magit-filenotify-data (make-hash-table)
   "A hash table to map watch-descriptors to a list (DIRECTORY STATUS-BUFFER).")
-
-(defvar magit-filenotify-ignored '("\\`\\.#"
-                                   "\\`flycheck_")
-  "A list of regexp for filenames that will be ignored by the callback.")
 
 (defun magit-filenotify--callback (ev)
   "Handle file-notify callbacks.


### PR DESCRIPTION
I'm having quite nasty lag because of temp files created for syntax checking which trigger magit-refresh like crazy.

I try to resolve that here with a list of files that the callback should ignore. Do you think that this could be merged?
