### PR TITLE
 magit-filenotify--directories: use magit-decode-git-paths

### DIFF
--- a/magit-filenotify.el
+++ b/magit-filenotify.el
@@ -47,7 +47,6 @@
 
 (defun magit-filenotify--directories ()
   "List all directories containing files watched by git."
-  ;; TODO: add .git directory?
   (cons
    default-directory
    (cl-remove-duplicates

--- a/magit-filenotify.el
+++ b/magit-filenotify.el
@@ -150,5 +150,7 @@ This can only be called from a magit status buffer."
   (easy-menu-remove-item magit-mode-menu nil "Auto Refresh"))
 
 (provide 'magit-filenotify)
-
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
 ;;; magit-filenotify.el ends here

--- a/magit-filenotify.el
+++ b/magit-filenotify.el
@@ -52,9 +52,9 @@
    default-directory
    (cl-remove-duplicates
     (cl-loop for file in (magit-git-lines "ls-files")
-             for tmp = (file-name-directory file)
-             when tmp
-             collect (expand-file-name tmp))
+             for dir = (file-name-directory (magit-decode-git-paths file))
+             when dir
+             collect (expand-file-name dir))
     :test #'string=)))
 
 (defvar magit-filenotify-data (make-hash-table)


### PR DESCRIPTION
`git ls-files` quotes filenames with special characters, decode them using `magit-decode-git-paths`.  Fix #5.

... and some cleanup.