### PR TITLE
Mention when this mode is useful, and when it is not.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,12 +1,51 @@
 # -*- mode:org; mode:auto-fill; fill-column:80; coding:utf-8; -*-
-* magit-filenotify --- Refresh status buffer when git tree changes
-This module for [[http://magit.vc/][magit]] provides an auto update mode for the status buffer.  It
-uses the file notification support that was added to Emacs 24.4.
+* Refresh status buffer when git tree changes
 
-This is an updated version of the obsolete =contrib/magit-inotify.el= mode.
+This extension to [[http://magit.vc/][Magit]] provides a minor-mode which, when enabled, automatically
+updates a repository's status buffer whenever a file inside that repository's
+working tree has changed.  It uses the file notification support that was added
+in Emacs v24.4.
 
-Activate the mode inside the =magit-status= buffer by calling
-=M-x magit-filenotify-mode [RET]=.  Repeat the same step to deactivate it again.
+** Should I use it?
 
-To always enable the mode when opening the =magit-status= buffer add
-=magit-filenotify-mode= to the =magit-status-mode-hook=.
+Note that Magit itself refreshes the appropriate status buffer whenever you run
+a Magit command.  (Before v2.3, Magit did only do so when the major-mode of the
+current buffer derives from ~magit-mode~, but now it does so whenever you run a
+Magit command, regardless of context.)
+
+Additionally, also starting with v2.3, Magit can be configured to also refresh a
+repository's status buffer whenever you save a buffer which visits a file which
+is being tracked in that repository.  Due to performance concerns that feature
+is not enabled by default, to enable it add this to your init file:
+
+#+BEGIN_SRC emacs-lisp
+  (add-hook 'after-save-hook 'magit-after-save-refresh-status)
+#+END_SRC
+
+After you have done that and assuming that you mostly interact with Git using
+Magit, then you don't need this package.  If a status buffer is out-of-date due
+to outside changes, you can always refresh it by simply pressing =g=.
+
+You can find more information about how Magit automatically refreshes buffers
+and about how to do it explicitly in its manual, in the node [[http://magit.vc/manual/magit/Automatic-refresh-and-revert.html][Automatic refresh
+and revert]].
+
+However if you often use Git on the command line and inside Magit in parallel,
+then you might want to avoid having to press =g= when coming back to the status
+buffer from the command line.  Enabling this mode avoids that.
+
+But also note that refreshing the status buffer can still be slow in big
+repositories.  If you are not satisfied with Magit's performance then you should
+probably not enable this mode, as that would refresh the status buffer even more
+often, in many cases needlessly.
+
+** How do I use it?
+
+To activate the minor-mode for a repository, open the status buffer for that
+repository and then call =M-x magit-filenotify-mode RET=.  Repeat the same step
+to deactivate the mode again.  To automatically enable the mode when opening
+a status buffer, add this to your init file:
+
+#+BEGIN_SRC emacs-lisp
+  (add-hook 'magit-status-mode-hook 'magit-filenotify-mode)
+#+END_SRC

--- a/magit-filenotify.el
+++ b/magit-filenotify.el
@@ -26,8 +26,10 @@
 
 ;; This module comes with a minor mode `magit-filenotify' which tracks
 ;; changes in the source tree using `file-notify' and refreshes the magit
-;; status buffer.  Emacs 24.4 with `file-notify-support' is required for it to
-;; work.
+;; status buffer.  Emacs 24.4 with `file-notify-support' is required for
+;; it to work.
+
+;; Also see https://github.com/magit/magit-filenotify for more information.
 
 ;;; Code:
 


### PR DESCRIPTION
Also drop support for older Magit releases. That way we no longer have to mention that it requires `file-notify-support` and therefore Emacs v24.4. The current Magit release depends on that anyway.
